### PR TITLE
Pipe found list files to single cmake-format call

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,6 @@
 
 cd "$GITHUB_WORKSPACE" || exit
 
-find . \( -name '*.cmake' -o -name 'CMakeLists.txt' \) -exec cmake-format $* {} \;
+find . \( -name '*.cmake' -o -name 'CMakeLists.txt' \) -exec cmake-format $* {} +
 
 exit $?


### PR DESCRIPTION
Fixes running with arg `--check` and other reasons why cmake-format would fail such as with a bad config.

Using `\;` invokes multiple calls to cmake-format with each file as an arguments, while `+` pipes all files into the arguments.

* With `\;`:
```bash
cmake-format $* ./test/CMakeLists.txt
cmake-format $* ./CMakeLists.txt
cmake-format $* ./CMakeModules/FindSDL2.cmake
cmake-format $* ./CMakeModules/Findspdlog.cmake
cmake-format $* ./CMakeModules/vcpkg_android.cmake
cmake-format $* ./src/CMakeLists.txt
```
exit codes of cmake-format are disposed of

* With `+`:
```bash
cmake-format $* ./test/CMakeLists.txt ./CMakeLists.txt ./CMakeModules/FindSDL2.cmake ./CMakeModules/Findspdlog.cmake ./CMakeModules/vcpkg_android.cmake ./src/CMakeLists.txt
```
exit code is maintained