### PR TITLE
Fix image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,10 @@ LABEL com.github.actions.description="Automatically formats CMake files to the r
 LABEL com.github.actions.icon="code"
 LABEL com.github.actions.color="blue"
 
-RUN pip3 install --upgrade pip && pip install "cmakelang[YAML]==0.6.13"
+RUN python -m pip install --no-cache-dir --upgrade pip && \
+    python -m pip install --no-cache-dir \
+        "Cython<3" \
+        "cmakelang[YAML]==0.6.13"
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Every GHA workflow that uses this action is broken because of https://github.com/yaml/pyyaml/issues/601 and https://github.com/yaml/pyyaml/issues/724.

Rather than force the PyYAML version to be < 6, which apparently has security issues, this forces the Cython version to be < 3.