### PR TITLE
Initial GitHub Actions-based CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
   schedule:
     - cron: 0 11 * * 2
   pull_request:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: 0 11 * * 2
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Gather metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            PuneetMatharu/cmake-format
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build and export to Docker
+        uses: docker/build-push-action@v4
+        with:
+          push: false
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Closes #7

This makes sure the image builds on every commit and PR, and also on a schedule in the event underlying dependencies cause breakage.  (I think the PyYAML problem was an exceptional case, but it does happen...)

Let me know if you don't want it to run on a schedule or this addition at all.