### PR TITLE
Allow users to specify the processed files via a regex

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,6 @@ LABEL com.github.actions.color="blue"
 RUN python -m pip install --no-cache-dir --upgrade pip && \
     python -m pip install --no-cache-dir "Cython<3" "cmakelang[YAML]==0.6.13"
 
-COPY entrypoint.sh /entrypoint.sh
+COPY entrypoint.py /entrypoint.py
 
-ARG PROCESS_FILES
-
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["python3", "/entrypoint.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,6 @@ RUN python -m pip install --no-cache-dir --upgrade pip && \
 
 COPY entrypoint.sh /entrypoint.sh
 
+ARG PROCESS_FILES
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For example
 
       # Regex to select which files to apply cmake-format on.
       # Defaults to '(.*\.cmake$|CMakeLists.txt$)'
-      file_regex: (.*\.cmake$|.*\.cmake\.in$|CMakeLists.txt$)'
+      file_regex: '(.*\.cmake$|.*\.cmake\.in$|CMakeLists.txt$)'
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For example
 
       # Regex to select which files to apply cmake-format on.
       # Defaults to '(.*\.cmake$|CMakeLists.txt$)'
-      file_regex: '(.*\.cmake$|.*\.cmake\.in$|CMakeLists.txt$)'
+      file-regex: '(.*\.cmake$|.*\.cmake\.in$|CMakeLists.txt$)'
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Formats CMake-specific files to the desired format using [`cmake-format`](https:
 
 ## Usage
 
-To use this action, pass arguments to the `args` element as you would to `cmake-format` - these arguments will be used to format each CMake file. For example
+To use this action, pass arguments to the `args` element as you would to `cmake-format` - these arguments will be used to format each CMake file. To select the files which should be processed use the `find_regex` argument.
+For example
 
 ```yaml
   - name: Format CMake files
@@ -31,6 +32,11 @@ To use this action, pass arguments to the `args` element as you would to `cmake-
       #   -c CONFIG_FILES [CONFIG_FILES ...], --config-files CONFIG_FILES [CONFIG_FILES ...]
       #                         path to configuration file(s)
       args: --config-files .cmake-format.json --in-place
+
+      # Regex to select which files to apply cmake-format on.
+      # Defaults to '(.*\.cmake$|CMakeLists.txt$)'
+      file_regex: (.*\.cmake$|.*\.cmake\.in$|CMakeLists.txt$)'
+
 ```
 
 You will probably want to pair this with a GitHub Action (such as

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ Formats CMake-specific files to the desired format using [`cmake-format`](https:
 
 ## Usage
 
-To use this action, pass arguments to the `args` element as you would to `cmake-format` - these arguments will be used to format each CMake file. To select the files which should be processed use the `find_regex` argument.
-For example
+To use this action, pass arguments to the `args` element as you would to `cmake-format` - these arguments will be used to format each CMake file. For more fine-grained control over which files to process, use the `find_regex` argument; see below for an example.
 
 ```yaml
   - name: Format CMake files

--- a/action.yaml
+++ b/action.yaml
@@ -28,7 +28,7 @@ inputs:
     required: true
     default: '--help'
 
-    file_regex: |
+    file-regex: |
       Regex to select which files to apply cmake-format on.
 
       Defaults to '(.*\.cmake$|CMakeLists.txt$)'
@@ -39,4 +39,4 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - --file_regex=\'${{ inputs.file_regex }}\' --cmake_format_args=\'${{ inputs.args }}\'
+    - --file-regex=\'${{ inputs.file_regex }}\' --cmake-format-args=\'${{ inputs.args }}\'

--- a/action.yaml
+++ b/action.yaml
@@ -27,8 +27,16 @@ inputs:
 
     required: true
     default: '--help'
+
+    file_regex: |
+      Arguments to set which files to apply cmake-format on.
+
+      Defaults to '(.*\.cmake$|CMakeLists.txt$)'
+    required: false
+    default: '(.*\.cmake$|CMakeLists.txt$)'
+
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - ${{ inputs.args }}
+    - --file_regex='${{ inputs.file_regex }}' --cmake_format_args='${{ inputs.args }}'

--- a/action.yaml
+++ b/action.yaml
@@ -39,4 +39,4 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - --file_regex='${{ inputs.file_regex }}' --cmake_format_args='${{ inputs.args }}'
+    - --file_regex=\'${{ inputs.file_regex }}\' --cmake_format_args=\'${{ inputs.args }}\'

--- a/action.yaml
+++ b/action.yaml
@@ -29,7 +29,7 @@ inputs:
     default: '--help'
 
     file_regex: |
-      Arguments to set which files to apply cmake-format on.
+      Regex to select which files to apply cmake-format on.
 
       Defaults to '(.*\.cmake$|CMakeLists.txt$)'
     required: false

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -6,10 +6,7 @@ import re
 import subprocess
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-                    prog='ProgramName',
-                    description='What the program does',
-                    epilog='Text at the bottom of help')
+    parser = argparse.ArgumentParser()
     parser.add_argument('--file_regex')
     parser.add_argument('--cmake_format_args')
     args = parser.parse_args()

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,0 +1,24 @@
+#!/bin/python3
+
+import os
+import argparse
+import re
+import subprocess
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+                    prog='ProgramName',
+                    description='What the program does',
+                    epilog='Text at the bottom of help')
+    parser.add_argument('--file_regex')
+    parser.add_argument('--cmake_format_args')
+    args = parser.parse_args()
+
+    regex = re.compile(rf"{args.file_regex}")
+
+    for root, dirs, files in os.walk(os.environ['GITHUB_WORKSPACE']):
+      for file in files:
+        if re.match(regex,file):
+           cmake_format_return = subprocess.run(["cmake-format", f"{args.cmake_format_args}",f"{os.path.join(root,file)}"],capture_output=True, text=True)
+           if cmake_format_return.returncode != 0:
+               print(cmake_format_return.stderr)

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,21 +1,50 @@
-#!/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import os
 import re
 import subprocess
+from pathlib import Path
+from multiprocessing import Pool
+from typing import List, Tuple, Optional
+
+
+def format_cmake_file(file_and_args: Tuple[Path, str]) -> Optional[str]:
+    (file_path, cmake_format_args) = file_and_args
+    cmake_command = f"cmake-format {cmake_format_args} {file_path}"
+    cmake_format_result = subprocess.run(cmake_command, shell=True, capture_output=True, text=True)
+    if cmake_format_result.returncode != 0:
+        return f"Error formatting {file_path}: {cmake_format_result.stderr}"
+    return None
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Format CMake files using cmake-format.")
+    parser.add_argument('--file-regex', required=True, help="Regex pattern to match filenames.")
+    parser.add_argument('--cmake-format-args', required=True, help="Additional arguments for cmake-format.")
+    args = parser.parse_args()
+    if len(args.file_regex) == 0:
+        parser.error("The --file-regex argument cannot be empty.")
+    return args
+
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--file-regex')
-    parser.add_argument('--cmake-format-args')
-    args = parser.parse_args()
+    args = parse_args()
 
-    regex = re.compile(rf"{args.file_regex}")
+    file_regex = re.compile(args.file_regex)
+    workspace_path = Path(os.environ['GITHUB_WORKSPACE'])
 
-    for root, dirs, files in os.walk(os.environ['GITHUB_WORKSPACE']):
-      for file in files:
-        if re.match(regex,file):
-           cmake_format_return = subprocess.run(["cmake-format", f"{args.cmake_format_args}",f"{os.path.join(root,file)}"],capture_output=True, text=True)
-           if cmake_format_return.returncode != 0:
-               print(cmake_format_return.stderr)
+    matched_files = [
+        (file_path, args.cmake_format_args)
+        for file_path in workspace_path.rglob('*')
+        if file_path.is_file() and file_regex.match(file_path.name)
+    ]
+
+    if len(matched_files) > 0:
+        with Pool() as pool:
+            format_results = pool.map(format_cmake_file, matched_files)
+        for result in format_results:
+            if result:
+                print(result)
+    else:
+        print("No files matched the given regex.")

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,7 +1,7 @@
 #!/bin/python3
 
-import os
 import argparse
+import os
 import re
 import subprocess
 

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -7,8 +7,8 @@ import subprocess
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('--file_regex')
-    parser.add_argument('--cmake_format_args')
+    parser.add_argument('--file-regex')
+    parser.add_argument('--cmake-format-args')
     args = parser.parse_args()
 
     regex = re.compile(rf"{args.file_regex}")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,8 @@
 
 cd "$GITHUB_WORKSPACE" || exit
 
-find . \( -name '*.cmake' -o -name '*.cmake.in' -o -name 'CMakeLists.txt' \) -exec cmake-format $* {} +
+FILE_REGEX="${PROCESS_FILES:-'*.cmake|CMakeLists.txt'}"
+
+find . -regex $FILE_REGEX -exec cmake-format $* {} +
 
 exit $?

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-cd "$GITHUB_WORKSPACE" || exit
-
-FILE_REGEX="${PROCESS_FILES:-'*.cmake|CMakeLists.txt'}"
-
-find . -regex $FILE_REGEX -exec cmake-format $* {} +
-
-exit $?

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,6 @@
 
 cd "$GITHUB_WORKSPACE" || exit
 
-find . \( -name '*.cmake' -o -name 'CMakeLists.txt' \) -exec cmake-format $* {} +
+find . \( -name '*.cmake' -o -name '*.cmake.in' -o -name 'CMakeLists.txt' \) -exec cmake-format $* {} +
 
 exit $?


### PR DESCRIPTION
This PR adds a user option (via environment vars) to specify which files should be processed. For this it uses the regex option of find.

This came up since we also use `.cmake.in` files and wanted them to be formatted as well